### PR TITLE
Updated go version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cnoe-io/argocd-api
 
-go 1.21.3
+go 1.22.0
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
Updated Go version in : https://github.com/cnoe-io/argocd-api/blob/main/go.mod
This PR is related to  : [#260](https://github.com/cnoe-io/idpbuilder/issues/260) of idpbuilder-CNOE