### PR TITLE
Updated K8s version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ $(LOCALBIN):
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 ## Tool Versions
-CONTROLLER_TOOLS_VERSION ?= v0.12.0
+CONTROLLER_TOOLS_VERSION ?= v0.15.0
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/sirupsen/logrus v1.9.3
 	google.golang.org/grpc v1.61.0
-	k8s.io/api v0.29.1
-	k8s.io/apiextensions-apiserver v0.29.1
-	k8s.io/apimachinery v0.29.1
+	k8s.io/api v0.30.0
+	k8s.io/apiextensions-apiserver v0.30.0
+	k8s.io/apimachinery v0.30.0
 	sigs.k8s.io/yaml v1.4.0
 )
 


### PR DESCRIPTION
## Description
This PR updates the Kubernetes dependencies in the `argocd-api` module to prevent a version mismatch.

## Changes Made
- Updated Kubernetes dependencies in `go.mod`:
  - `k8s.io/apiextensions-apiserver` from `v0.29.1` to `v0.30.0`.
  - `k8s.io/apimachinery` from `v0.29.1` to `v0.30.0`.
- Updated the `CONTROLLER_TOOLS_VERSION` in the `Makefile` from `v0.12.0` to `v0.15.0`.

## Reason for Changes
These changes ensure compatibility with the latest Kubernetes version and prevent issues related to version mismatches.

## Linked Issue
This PR addresses issue #4.
